### PR TITLE
Refactor: Board CRUD 리팩토링 #4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2964,7 +2964,6 @@
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-10.0.3.tgz",
       "integrity": "sha512-znJ9Y4S8ZDVY+j4doWAJ8EuuVO7SkQN3yOBmzxbGaXbvcSwFDAdGJ+OMCg52NdzIO4tQoN4pYKx8W6M0ArfFRQ==",
-      "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "passport": "^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0"
@@ -10846,7 +10845,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
-      "license": "MIT",
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -22,6 +22,7 @@ export class BoardController {
     };
   }
 
+  @UseGuards(AccessTokenGuard)
   @Get('/')
   async findAll(@Req() req: any) {
     // userId에 맞는 boards 찾기 필요
@@ -34,6 +35,7 @@ export class BoardController {
     };
   }
 
+  @UseGuards(AccessTokenGuard)
   @Get(':id')
   async findOne(@Param('id') id: string) {
     // lists와 cards 모두 출력되도록 변경 필요

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -1,18 +1,20 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, HttpStatus, Req } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, HttpStatus, Req, UseGuards } from '@nestjs/common';
 import { BoardService } from './board.service';
 import { CreateBoardDto } from './dto/create-board.dto';
 import { UpdateBoardDto } from './dto/update-board.dto';
+import { AccessTokenGuard } from 'src/auth/guards/access-token.guard';
 
 @Controller('boards')
 export class BoardController {
   constructor(private readonly boardService: BoardService) {}
 
   /** 보드 생성 */
+  @UseGuards(AccessTokenGuard)
   @Post('/')
   async create(@Body() createBoardDto: CreateBoardDto, @Req() req: any) {
-    // userId로 adminId 지정 필요
-    // const userId = num(req.user.id)
-    const board = await this.boardService.create(createBoardDto);
+    // userId로 adminId 지정
+    const userId = Number(req.user.id);
+    const board = await this.boardService.create(userId, createBoardDto);
     return {
       status: HttpStatus.CREATED,
       message: '보드 생성에 성공했습니다.',
@@ -43,6 +45,7 @@ export class BoardController {
     };
   }
 
+  @UseGuards(AccessTokenGuard)
   @Patch(':id')
   async update(@Param('id') id: string, @Body() updateBoardDto: UpdateBoardDto) {
     // 수정 권한에 대해 생각 필요
@@ -55,6 +58,7 @@ export class BoardController {
     };
   }
 
+  @UseGuards(AccessTokenGuard)
   @Delete(':id')
   async remove(@Param('id') id: string) {
     // 삭제 권한에 대해 생각 필요

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -42,6 +42,7 @@ export class BoardController {
   async findOne(@Param('id') id: string) {
     // lists와 cards 모두 출력되도록 변경 필요
     const board = await this.boardService.findOne(+id);
+    // boardId가 포함된 lists 불러오기
     const lists = await this.listService.findAll(+id);
     return {
       status: HttpStatus.OK,
@@ -66,10 +67,10 @@ export class BoardController {
 
   @UseGuards(AccessTokenGuard)
   @Delete(':id')
-  async remove(@Param('id') id: string) {
-    // 삭제 권한에 대해 생각 필요
+  async remove(@Param('id') id: string, @Req() req: any) {
     // board 삭제 시 lists와 cards 함께 삭제 필요
-    const delededBoard = await this.boardService.delete(+id);
+    const userId = Number(req.user.id);
+    const delededBoard = await this.boardService.delete(+id, userId);
     return {
       status: HttpStatus.OK,
       message: '보드 삭제에 성공했습니다.',

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -54,7 +54,6 @@ export class BoardController {
   @UseGuards(AccessTokenGuard)
   @Patch(':id')
   async update(@Param('id') id: string, @Body() updateBoardDto: UpdateBoardDto) {
-    // 수정 권한에 대해 생각 필요
     const { title, backgroundColor } = updateBoardDto;
     const updatedBoard = await this.boardService.update(+id, updateBoardDto);
     return {

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -25,8 +25,6 @@ export class BoardController {
   @UseGuards(AccessTokenGuard)
   @Get('/')
   async findAll(@Req() req: any) {
-    // userId에 맞는 boards 찾기 필요
-    // const userId = req.user.id;
     const boards = await this.boardService.findAll();
     return {
       status: HttpStatus.OK,

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -53,9 +53,10 @@ export class BoardController {
 
   @UseGuards(AccessTokenGuard)
   @Patch(':id')
-  async update(@Param('id') id: string, @Body() updateBoardDto: UpdateBoardDto) {
+  async update(@Param('id') id: string, @Req() req: any, @Body() updateBoardDto: UpdateBoardDto) {
+    const userId = Number(req.user.id);
     const { title, backgroundColor } = updateBoardDto;
-    const updatedBoard = await this.boardService.update(+id, updateBoardDto);
+    const updatedBoard = await this.boardService.update(+id, userId, updateBoardDto);
     return {
       status: HttpStatus.OK,
       message: '보드 수정에 성공했습니다.',

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -3,10 +3,14 @@ import { BoardService } from './board.service';
 import { CreateBoardDto } from './dto/create-board.dto';
 import { UpdateBoardDto } from './dto/update-board.dto';
 import { AccessTokenGuard } from 'src/auth/guards/access-token.guard';
+import { ListService } from 'src/list/list.service';
 
 @Controller('boards')
 export class BoardController {
-  constructor(private readonly boardService: BoardService) {}
+  constructor(
+    private readonly boardService: BoardService,
+    private readonly listService: ListService,
+  ) {}
 
   /** 보드 생성 */
   @UseGuards(AccessTokenGuard)
@@ -38,10 +42,12 @@ export class BoardController {
   async findOne(@Param('id') id: string) {
     // lists와 cards 모두 출력되도록 변경 필요
     const board = await this.boardService.findOne(+id);
+    const lists = await this.listService.findAll(+id);
     return {
       status: HttpStatus.OK,
       message: '보드 상세 조회에 성공했습니다.',
       board,
+      lists,
     };
   }
 

--- a/src/board/board.module.ts
+++ b/src/board/board.module.ts
@@ -3,10 +3,12 @@ import { BoardService } from './board.service';
 import { BoardController } from './board.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Board } from './entities/board.entity';
+import { ListService } from 'src/list/list.service';
+import { List } from 'src/list/entities/list.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Board])],
+  imports: [TypeOrmModule.forFeature([Board, List])],
   controllers: [BoardController],
-  providers: [BoardService],
+  providers: [BoardService, ListService],
 })
 export class BoardModule {}

--- a/src/board/board.module.ts
+++ b/src/board/board.module.ts
@@ -5,10 +5,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Board } from './entities/board.entity';
 import { ListService } from 'src/list/list.service';
 import { List } from 'src/list/entities/list.entity';
+import { Card } from 'src/card/entities/card.entity';
+import { CardService } from 'src/card/card.service';
+import { CardAssignee } from 'src/card/entities/card_assignee.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Board, List])],
+  imports: [TypeOrmModule.forFeature([Board, List, Card, CardAssignee])],
   controllers: [BoardController],
-  providers: [BoardService, ListService],
+  providers: [BoardService, ListService, CardService],
 })
 export class BoardModule {}

--- a/src/board/board.module.ts
+++ b/src/board/board.module.ts
@@ -8,9 +8,10 @@ import { List } from 'src/list/entities/list.entity';
 import { Card } from 'src/card/entities/card.entity';
 import { CardService } from 'src/card/card.service';
 import { CardAssignee } from 'src/card/entities/card_assignee.entity';
+import { BoardMember } from './entities/board-member.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Board, List, Card, CardAssignee])],
+  imports: [TypeOrmModule.forFeature([Board, List, Card, CardAssignee, BoardMember])],
   controllers: [BoardController],
   providers: [BoardService, ListService, CardService],
 })

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { CreateBoardDto } from './dto/create-board.dto';
 import { UpdateBoardDto } from './dto/update-board.dto';
 import { InjectRepository } from '@nestjs/typeorm';

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -9,10 +9,11 @@ import { Repository } from 'typeorm';
 export class BoardService {
   constructor(@InjectRepository(Board) private readonly boardRepository: Repository<Board>) {}
 
-  async create(createBoardDto: CreateBoardDto) {
-    const { title, backgroundColor, adminId } = createBoardDto;
+  async create(userId: number, createBoardDto: CreateBoardDto) {
+    const { title, backgroundColor } = createBoardDto;
+    // adminId를 userId로 등록
     const board = await this.boardRepository.save({
-      adminId,
+      adminId: userId,
       title,
       backgroundColor,
     });

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { CreateBoardDto } from './dto/create-board.dto';
 import { UpdateBoardDto } from './dto/update-board.dto';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -39,7 +39,19 @@ export class BoardService {
     return board;
   }
 
-  async update(id: number, updateBoardDto: UpdateBoardDto) {
+  async update(id: number, userId, updateBoardDto: UpdateBoardDto) {
+    const board = await this.boardRepository.findOne({
+      where: {
+        id,
+      },
+    });
+    if (!board) {
+      throw new NotFoundError('보드가 존재하지 않습니다.');
+    }
+    // board의 admin만 수정 가능
+    if (userId !== board.adminId) {
+      throw new UnauthorizedException('수정 권한이 없습니다.');
+    }
     const updatingBoard = await this.boardRepository.update(id, updateBoardDto);
     const updatedBoard = await this.boardRepository.findOne({
       where: {

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -1,14 +1,20 @@
-import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { CreateBoardDto } from './dto/create-board.dto';
 import { UpdateBoardDto } from './dto/update-board.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Board } from './entities/board.entity';
 import { Repository } from 'typeorm';
 import { NotFoundError } from 'rxjs';
+import { BoardMember } from './entities/board-member.entity';
+import { BoardMemberType } from './types/board-member.type';
 
 @Injectable()
 export class BoardService {
-  constructor(@InjectRepository(Board) private readonly boardRepository: Repository<Board>) {}
+  constructor(
+    @InjectRepository(Board) private readonly boardRepository: Repository<Board>,
+    @InjectRepository(BoardMember)
+    private readonly boardMemberRepository: Repository<BoardMember>,
+  ) {}
 
   async create(userId: number, createBoardDto: CreateBoardDto) {
     const { title, backgroundColor, description } = createBoardDto;
@@ -18,6 +24,12 @@ export class BoardService {
       title,
       backgroundColor,
       description,
+    });
+
+    const boardMember = await this.boardMemberRepository.save({
+      boardId: board.id,
+      memberId: userId,
+      memberType: BoardMemberType.ADMIN,
     });
     return board;
   }

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -10,12 +10,13 @@ export class BoardService {
   constructor(@InjectRepository(Board) private readonly boardRepository: Repository<Board>) {}
 
   async create(userId: number, createBoardDto: CreateBoardDto) {
-    const { title, backgroundColor } = createBoardDto;
+    const { title, backgroundColor, description } = createBoardDto;
     // adminId를 userId로 등록
     const board = await this.boardRepository.save({
       adminId: userId,
       title,
       backgroundColor,
+      description,
     });
     return board;
   }
@@ -45,7 +46,7 @@ export class BoardService {
   }
 
   async delete(id: number) {
-    const deletingBoard = await this.boardRepository.delete(id)
+    const deletingBoard = await this.boardRepository.delete(id);
     return;
   }
 }

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -39,7 +39,7 @@ export class BoardService {
     return board;
   }
 
-  async update(id: number, userId, updateBoardDto: UpdateBoardDto) {
+  async update(id: number, userId: number, updateBoardDto: UpdateBoardDto) {
     const board = await this.boardRepository.findOne({
       where: {
         id,
@@ -61,7 +61,19 @@ export class BoardService {
     return updatedBoard;
   }
 
-  async delete(id: number) {
+  async delete(id: number, userId: number) {
+    const board = await this.boardRepository.findOne({
+      where: {
+        id,
+      },
+    });
+    if (!board) {
+      throw new NotFoundError('보드가 존재하지 않습니다.');
+    }
+    // board의 admin만 삭제 가능
+    if (userId !== board.adminId) {
+      throw new UnauthorizedException('삭제 권한이 없습니다.');
+    }
     const deletingBoard = await this.boardRepository.delete(id);
     return;
   }

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -4,6 +4,7 @@ import { UpdateBoardDto } from './dto/update-board.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Board } from './entities/board.entity';
 import { Repository } from 'typeorm';
+import { NotFoundError } from 'rxjs';
 
 @Injectable()
 export class BoardService {
@@ -32,6 +33,9 @@ export class BoardService {
         id,
       },
     });
+    if (!board) {
+      throw new NotFoundError('보드가 존재하지 않습니다.');
+    }
     return board;
   }
 

--- a/src/board/dto/create-board.dto.ts
+++ b/src/board/dto/create-board.dto.ts
@@ -10,4 +10,8 @@ export class CreateBoardDto {
 
   @IsHexColor()
   backgroundColor: string;
+
+  @IsNotEmpty({ message: '보드 설명을 입력해주세요.' })
+  @IsString()
+  description: string;
 }

--- a/src/board/dto/create-board.dto.ts
+++ b/src/board/dto/create-board.dto.ts
@@ -8,7 +8,8 @@ export class CreateBoardDto {
   @IsString()
   title: string;
 
-  @IsHexColor()
+  @IsOptional()
+  @IsString()
   backgroundColor: string;
 
   @IsNotEmpty({ message: '보드 설명을 입력해주세요.' })

--- a/src/board/dto/update-board.dto.ts
+++ b/src/board/dto/update-board.dto.ts
@@ -10,4 +10,8 @@ export class UpdateBoardDto extends PartialType(CreateBoardDto) {
   @IsOptional()
   @IsHexColor()
   backgroundColor?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
 }

--- a/src/board/entities/board-member.entity.ts
+++ b/src/board/entities/board-member.entity.ts
@@ -12,7 +12,7 @@ import { BoardMemberType } from '../types/board-member.type';
 import { Board } from './board.entity';
 import { User } from 'src/user/entities/user.entity';
 
-@Entity('boards/members')
+@Entity('board_members')
 export class BoardMember {
   @PrimaryGeneratedColumn({ unsigned: true, type: 'int' })
   id: number;

--- a/src/board/entities/board.entity.ts
+++ b/src/board/entities/board.entity.ts
@@ -27,6 +27,9 @@ export class Board {
   @Column({ name: 'background_color', type: 'varchar', default: '#A52A2A' })
   backgroundColor: string;
 
+  @Column({ type: 'text' })
+  description: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/card/card.service.ts
+++ b/src/card/card.service.ts
@@ -93,4 +93,16 @@ export class CardService {
 
     await this.cardRepository.softDelete({ id });
   }
+
+  // board 상세조회 시 cards 가져오기
+  async findAll(listId: number) {
+    const cards = await this.cardRepository.find({
+      where: {
+        list: {
+          id: listId,
+        },
+      },
+    });
+    return cards;
+  }
 }

--- a/src/list/list.service.ts
+++ b/src/list/list.service.ts
@@ -76,4 +76,10 @@ export class ListService {
     await this.listsRepository.save(list);
     return list;
   }
+
+  // board 상세조회 시 lists 불러오기
+  async findAll(boardId: number) {
+    const lists = await this.listsRepository.findBy({ boardId });
+    return lists;
+  }
 }


### PR DESCRIPTION
CRUD 각각 PR을 올리려다가 애매해서 한번에 올리겠습니다.

refactor: adminId를 userId로 가져오기 #4
(board 생성 시 로그인한 userId를 adminId로 지정)

refactor: board 생성 및 수정 시 description 항목 추가 #4
(발제 문서 참고하여 변경)

refactor: board 생성 시 backgroundcolor optional로 변경 #4
(default 값 지정하여 optional로 변경)

refactor: board 상세조회 시 lists 출력 #4

refactor: board 상세조회시 NotFoundError 추가 #4

refactor: board 수정 시 admin 권한 설정 #4
(발제 문서 참고하여 변경)

refactor: board 삭제 시 admin 권한 설정 #4
(삭제도 수정과 동일하게 변경했는데 팀원 의견 확인 필요)

refactor: board 상세조회 시 lists, cards 불러오기 #4
-> 해당 부분 작업하면서 list.service와 card.service에 findAll 함수 만들었습니다.

refactor: board 생성 시 board-members 생성 #4
(board 생성한 userId를 memberId로 넣고 ADMIN으로 지정)